### PR TITLE
venv integration

### DIFF
--- a/racecar-student/scripts/requirements.txt
+++ b/racecar-student/scripts/requirements.txt
@@ -1,5 +1,5 @@
 numpy == 1.21.2
-matplotlib
+matplotlib == 3.8.4
 pandas == 2.0.3
 mypy
 nptyping == 1.4.4

--- a/racecar-student/scripts/setup.sh
+++ b/racecar-student/scripts/setup.sh
@@ -14,6 +14,9 @@ SCRIPT_DIR=$(dirname "$SCRIPT_PATH")
 # Extract the racecar-student directory
 RACECAR_DIR=$(dirname "$SCRIPT_DIR")
 
+# Extract the racecar-neo-installer directory
+NEO_DIR=$(dirname "$RACECAR_DIR")
+
 echo 'Welcome to the RACECAR Neo command-line installer for Windows, Mac, and Linux.'
 
 
@@ -72,6 +75,19 @@ if [ "$PLATFORM" == 'windows' ]; then
     yes | sudo apt upgrade
     yes | sudo apt install python-is-python3
     yes | sudo apt install python3-pip
+
+    # Setting up venv for Python 3.9
+    yes | sudo add-apt-repository ppa:deadsnakes/ppa
+    yes | sudo apt update
+    yes | sudo apt install python3.9
+    yes | sudo apt install python3.9-venv
+
+    cd "$SCRIPT_DIR"/../..
+    python3.9 -m venv racecar-venv
+    source racecar-venv/bin/activate
+    echo "${NEO_DIR}/racecar-venv/bin/activate" >> ~/.bashrc
+
+    # continue with regular setup
     yes | pip install -r "${SCRIPT_DIR}"/requirements.txt
     yes | sudo apt install jupyter-notebook
     yes | sudo apt install ffmpeg libsm6 libxext6 -y
@@ -103,6 +119,18 @@ elif [ "$PLATFORM" == 'linux' ]; then
     yes | sudo apt upgrade
     yes | sudo apt install python-is-python3
     yes | sudo apt install python3-pip
+
+    # Setting up venv for Python 3.9
+    yes | sudo add-apt-repository ppa:deadsnakes/ppa
+    yes | sudo apt update
+    yes | sudo apt install python3.9
+    yes | sudo apt install python3.9-venv
+
+    cd "$SCRIPT_DIR"/../..
+    python3.9 -m venv racecar-venv
+    source racecar-venv/bin/activate
+    echo "${NEO_DIR}/racecar-venv/bin/activate" >> ~/.bashrc
+
     yes | pip install -r "${SCRIPT_DIR}"/requirements.txt
     yes | sudo apt install jupyter-notebook
     yes | sudo apt install ffmpeg libsm6 libxext6 -y
@@ -145,6 +173,14 @@ elif [ "$PLATFORM" == 'mac' ]; then
     echo 'export PATH="/usr/local/opt/python/libexec/bin:$PATH"'  
 
     python3 -m pip install --upgrade pip
+
+    # Set up venv on mac
+    brew install python@3.9
+    cd "$SCRIPT_DIR"/../..
+    python3.9 -m venv racecar-venv
+    source racecar-venv/bin/activate
+    echo "${NEO_DIR}/racecar-venv/bin/activate" >> ~/.bashrc
+    echo "${NEO_DIR}/racecar-venv/bin/activate" >> ~/.zshrc
 
     yes | pip3 install -r "${SCRIPT_DIR}"/requirements.txt
 

--- a/racecar-student/scripts/setup.sh
+++ b/racecar-student/scripts/setup.sh
@@ -84,7 +84,6 @@ if [ "$PLATFORM" == 'windows' ]; then
 
     cd "$SCRIPT_DIR"/../..
     python3.9 -m venv racecar-venv
-    source racecar-venv/bin/activate
     echo "source ${NEO_DIR}/racecar-venv/bin/activate" >> ~/.bashrc
 
     # continue with regular setup
@@ -128,7 +127,6 @@ elif [ "$PLATFORM" == 'linux' ]; then
 
     cd "$SCRIPT_DIR"/../..
     python3.9 -m venv racecar-venv
-    source racecar-venv/bin/activate
     echo "source ${NEO_DIR}/racecar-venv/bin/activate" >> ~/.bashrc
 
     yes | pip install -r "${SCRIPT_DIR}"/requirements.txt
@@ -178,7 +176,6 @@ elif [ "$PLATFORM" == 'mac' ]; then
     brew install python@3.9
     cd "$SCRIPT_DIR"/../..
     python3.9 -m venv racecar-venv
-    source racecar-venv/bin/activate
     echo "source ${NEO_DIR}/racecar-venv/bin/activate" >> ~/.bashrc
     echo "source ${NEO_DIR}/racecar-venv/bin/activate" >> ~/.zshrc
 

--- a/racecar-student/scripts/setup.sh
+++ b/racecar-student/scripts/setup.sh
@@ -6,7 +6,8 @@ LIB_URL="https://github.com/MITRacecarNeo/racecar-neo-library.git"
 CURR_URL="https://github.com/MITRacecarNeo/racecar-neo-"
 
 # Get the full path of the current script
-SCRIPT_PATH=$(realpath "$0")
+# SCRIPT_PATH=$(realpath "$0")
+SCRIPT_PATH=$(readlink -f "$0" 2>/dev/null || echo "$(cd "$(dirname "$0")"; pwd)/$(basename "$0")")
 
 # Extract the directory from the full path
 SCRIPT_DIR=$(dirname "$SCRIPT_PATH")

--- a/racecar-student/scripts/setup.sh
+++ b/racecar-student/scripts/setup.sh
@@ -85,7 +85,7 @@ if [ "$PLATFORM" == 'windows' ]; then
     cd "$SCRIPT_DIR"/../..
     python3.9 -m venv racecar-venv
     source racecar-venv/bin/activate
-    echo "$source {NEO_DIR}/racecar-venv/bin/activate" >> ~/.bashrc
+    echo "source ${NEO_DIR}/racecar-venv/bin/activate" >> ~/.bashrc
 
     # continue with regular setup
     yes | pip install -r "${SCRIPT_DIR}"/requirements.txt
@@ -179,8 +179,8 @@ elif [ "$PLATFORM" == 'mac' ]; then
     cd "$SCRIPT_DIR"/../..
     python3.9 -m venv racecar-venv
     source racecar-venv/bin/activate
-    echo "$source {NEO_DIR}/racecar-venv/bin/activate" >> ~/.bashrc
-    echo "$source {NEO_DIR}/racecar-venv/bin/activate" >> ~/.zshrc
+    echo "source ${NEO_DIR}/racecar-venv/bin/activate" >> ~/.bashrc
+    echo "source ${NEO_DIR}/racecar-venv/bin/activate" >> ~/.zshrc
 
     yes | pip3 install -r "${SCRIPT_DIR}"/requirements.txt
 

--- a/racecar-student/scripts/setup.sh
+++ b/racecar-student/scripts/setup.sh
@@ -85,7 +85,7 @@ if [ "$PLATFORM" == 'windows' ]; then
     cd "$SCRIPT_DIR"/../..
     python3.9 -m venv racecar-venv
     source racecar-venv/bin/activate
-    echo "${NEO_DIR}/racecar-venv/bin/activate" >> ~/.bashrc
+    echo "$source {NEO_DIR}/racecar-venv/bin/activate" >> ~/.bashrc
 
     # continue with regular setup
     yes | pip install -r "${SCRIPT_DIR}"/requirements.txt
@@ -129,7 +129,7 @@ elif [ "$PLATFORM" == 'linux' ]; then
     cd "$SCRIPT_DIR"/../..
     python3.9 -m venv racecar-venv
     source racecar-venv/bin/activate
-    echo "${NEO_DIR}/racecar-venv/bin/activate" >> ~/.bashrc
+    echo "source ${NEO_DIR}/racecar-venv/bin/activate" >> ~/.bashrc
 
     yes | pip install -r "${SCRIPT_DIR}"/requirements.txt
     yes | sudo apt install jupyter-notebook
@@ -179,8 +179,8 @@ elif [ "$PLATFORM" == 'mac' ]; then
     cd "$SCRIPT_DIR"/../..
     python3.9 -m venv racecar-venv
     source racecar-venv/bin/activate
-    echo "${NEO_DIR}/racecar-venv/bin/activate" >> ~/.bashrc
-    echo "${NEO_DIR}/racecar-venv/bin/activate" >> ~/.zshrc
+    echo "$source {NEO_DIR}/racecar-venv/bin/activate" >> ~/.bashrc
+    echo "$source {NEO_DIR}/racecar-venv/bin/activate" >> ~/.zshrc
 
     yes | pip3 install -r "${SCRIPT_DIR}"/requirements.txt
 


### PR DESCRIPTION
Integrated automation of setting up a virtual environment for Python3.9 for Mac, Windows, and Linux.

Fixes the following issues:
- System version of Python >3.9
- Dependency version conflict for matplotlib (numpy, nptyping)
- Script path acquisition for older Mac devices