### PR TITLE
Fix Syntax Error in `.config` From Setup Script for Linux

### DIFF
--- a/racecar-student/scripts/setup.sh
+++ b/racecar-student/scripts/setup.sh
@@ -145,7 +145,7 @@ elif [ "$PLATFORM" == 'linux' ]; then
 RACECAR_IP=127.0.0.1
 RACECAR_TEAM=student
 RACECAR_CONFIG_LOADED=TRUE
-sudo sysctl -w net.ipv4.udp_mem="65535 131071 262142"" > "${SCRIPT_DIR}/.config"
+sudo sysctl -w net.ipv4.udp_mem=\"65535 131071 262142\"" > "${SCRIPT_DIR}/.config"
 
     # Linux tool command
     sed '/# RACECAR_ALIASES$/d' -i ~/.bashrc


### PR DESCRIPTION
I was reading the setup procedure for the BWSI prerequisite course, and after running setup.sh, I got an error: `sysctl: command line(0): invalid syntax, continuing...`.

The `sysctl` command in `.config` was missing quotes because the setup script didn't escape them when it created `.config`:
https://github.com/MITRacecarNeo/racecar-neo-installer/blob/6111ed1fcffcfc8d7facf2c70239f8c0b3ea683a/racecar-student/scripts/setup.sh#L141-L145

This only affects Linux. Windows & macOS have no quotes in `.config`.

This PR just escapes those quotes to fix this error.

I was able to reproduce this on Ubuntu 22.04.5 LTS: after running the installation script, selecting linux (3), selecting prereq (3), and sourcing `.bashrc` after the script finished, the following error is outputted.
```
net.ipv4.udp_mem = 65535
sysctl: "131071" must be of the form name=value
sysctl: "262142" must be of the form name=value
```
I also reproduced this on Arch Linux (with sysctl from procps-ng 4.0.6), the error message is:
```
net.ipv4.udp_mem = 65535
sysctl: command line(0): invalid syntax, continuing...
sysctl: command line(0): invalid syntax, continuing...
```
Many `racecar` commands will still work despite the error, but UDP memory page thresholds will not be configured correctly like the script is trying to.