### PR TITLE
Installer hardening: bug fixes, parallel clones, lazy UDP, JupyterLab

### DIFF
--- a/racecar-student/scripts/racecar_tool.sh
+++ b/racecar-student/scripts/racecar_tool.sh
@@ -1,6 +1,45 @@
 #!/bin/bash
 # Creates the racecar tool for easily using and communicating with a RACECAR
 
+# Raise the UDP buffer once per shell session, only when actually needed.
+# Called from 'racecar sim'. No-op on WSL (Windows handles buffers itself) and
+# no-op if the kernel already has the desired value, so sudo only prompts when
+# the value really needs changing.
+_racecar_tune_udp() {
+  [ "$RACECAR_UDP_TUNED" = "1" ] && return 0
+
+  if grep -qi "microsoft" /proc/version 2>/dev/null; then
+    export RACECAR_UDP_TUNED=1
+    return 0
+  fi
+
+  if ! command -v sysctl >/dev/null 2>&1; then
+    export RACECAR_UDP_TUNED=1
+    return 0
+  fi
+
+  local key want
+  case "$(uname)" in
+    Linux)  key="net.ipv4.udp_mem";      want="65535 131071 262142" ;;
+    Darwin) key="net.inet.udp.maxdgram"; want="65535" ;;
+    *)      export RACECAR_UDP_TUNED=1; return 0 ;;
+  esac
+
+  local current
+  current=$(sysctl -n "$key" 2>/dev/null | tr -s '[:space:]' ' ' | sed 's/^ //;s/ $//')
+  if [ "$current" = "$want" ]; then
+    export RACECAR_UDP_TUNED=1
+    return 0
+  fi
+
+  echo "Tuning UDP buffer (${key}) — sudo password may be required (one time per session)..."
+  if sudo sysctl -w "${key}=\"${want}\"" >/dev/null; then
+    export RACECAR_UDP_TUNED=1
+  else
+    echo "Warning: could not raise UDP buffer. Simulator may drop packets under load."
+  fi
+}
+
 racecar() {
   if [ "$RACECAR_CONFIG_LOADED" != "TRUE" ]; then
     echo "Error: unable to find your local .config file.  Please make sure that you setup the racecar tool correctly."
@@ -23,8 +62,8 @@ racecar() {
     jupyter)
       local prev_dir="$PWD"
       cd "$RACECAR_ABSOLUTE_PATH"/labs || return
-      echo "Creating a Jupyter server..."
-      jupyter-notebook --no-browser
+      echo "Creating a JupyterLab server..."
+      jupyter lab --no-browser
       cd "$prev_dir" || return
       ;;
 
@@ -50,6 +89,7 @@ racecar() {
         echo "Usage: racecar sim <filename.py> [additional arguments...]"
         return 1
       fi
+      _racecar_tune_udp
       shift  # remove "sim" from args
       local script="$1"; shift  # grab the filename
       python3 "$script" -s "$@"
@@ -115,7 +155,7 @@ racecar() {
       echo "  racecar cd                  move to the racecar labs directory on your computer."
       echo "  racecar connect             connects to your car with ssh."
       echo "  racecar help                prints this help message."
-      echo "  racecar jupyter             starts a jupyter server in the racecar labs directory."
+      echo "  racecar jupyter             starts a JupyterLab server in the racecar labs directory."
       echo "  racecar remove              removes your team directory from your car."
       echo "  racecar setup               sets up your team directory on your car."
       echo "  racecar sim <file.py>       runs the specified racecar program with the simulator."

--- a/racecar-student/scripts/racecar_tool.sh
+++ b/racecar-student/scripts/racecar_tool.sh
@@ -95,6 +95,107 @@ racecar() {
       python3 "$script" -s "$@"
       ;;
 
+    open_sim)
+      # Locate the simulator folder. RACECAR_ABSOLUTE_PATH is the racecar-student
+      # dir; the simulator lives one level up alongside it (and on Windows, that
+      # path is a symlink into /mnt/c/Users/<user>/RacecarNeo-Simulator).
+      local sim_root="$(dirname "$RACECAR_ABSOLUTE_PATH")/RacecarNeo-Simulator"
+      if [ ! -d "$sim_root" ]; then
+        echo "Error: simulator folder not found at ${sim_root}."
+        echo "Run setup.sh or 'bash \$(dirname \"\$RACECAR_ABSOLUTE_PATH\")/racecar-student/scripts/update.sh' to install it."
+        return 1
+      fi
+
+      # The simulator builds are packaged as RacecarSim_<Platform>_v<version>/.
+      # Pick the first match so version bumps don't break this command.
+      local sim_build
+      sim_build=$(find -L "$sim_root" -maxdepth 1 -mindepth 1 -type d -name 'RacecarSim_*' | head -n1)
+      if [ -z "$sim_build" ]; then
+        echo "Error: no RacecarSim_* build folder found inside ${sim_root}."
+        return 1
+      fi
+
+      # Detect host OS and launch the right binary.
+      if grep -qi "microsoft" /proc/version 2>/dev/null; then
+        # WSL — invoke the .exe through cmd.exe so Windows owns the process and
+        # resolves DLLs from a real NTFS path (not a \\wsl.localhost UNC path).
+        local exe_path="${sim_build}/RacecarSim.exe"
+        if [ ! -f "$exe_path" ]; then
+          echo "Error: RacecarSim.exe not found at ${exe_path}."
+          return 1
+        fi
+        local win_path
+        win_path=$(wslpath -w "$exe_path" 2>/dev/null)
+        if [ -z "$win_path" ]; then
+          echo "Error: could not translate ${exe_path} to a Windows path via wslpath."
+          return 1
+        fi
+        echo "Launching simulator: ${win_path}"
+        ( cd "$sim_build" && cmd.exe /c start "" "$win_path" ) >/dev/null 2>&1 &
+        disown 2>/dev/null
+      elif [ "$(uname)" = "Darwin" ]; then
+        local app_path
+        app_path=$(find -L "$sim_build" -maxdepth 1 -mindepth 1 -name 'RacecarSim*.app' | head -n1)
+        if [ -z "$app_path" ]; then
+          echo "Error: RacecarSim*.app bundle not found in ${sim_build}."
+          return 1
+        fi
+        echo "Launching simulator: ${app_path}"
+        open "$app_path"
+      elif [ "$(uname)" = "Linux" ]; then
+        local lin_exe
+        lin_exe=$(find -L "$sim_build" -maxdepth 1 -mindepth 1 -type f \( -name 'RacecarSim.x86_64' -o -name 'RacecarSim' \) | head -n1)
+        if [ -z "$lin_exe" ]; then
+          echo "Error: RacecarSim Linux binary not found in ${sim_build}."
+          return 1
+        fi
+        chmod +x "$lin_exe" 2>/dev/null
+        echo "Launching simulator: ${lin_exe}"
+        ( cd "$sim_build" && "$lin_exe" ) >/dev/null 2>&1 &
+        disown 2>/dev/null
+      else
+        echo "Error: unrecognized OS. 'racecar open_sim' supports Windows (WSL), Mac, and Linux."
+        return 1
+      fi
+      ;;
+
+    open_sim_folder)
+      local sim_root="$(dirname "$RACECAR_ABSOLUTE_PATH")/RacecarNeo-Simulator"
+      if [ ! -d "$sim_root" ]; then
+        echo "Error: simulator folder not found at ${sim_root}."
+        return 1
+      fi
+
+      if grep -qi "microsoft" /proc/version 2>/dev/null; then
+        # Resolve the symlink so Explorer opens the real /mnt/c path, not \\wsl.localhost.
+        local real_root
+        real_root=$(readlink -f "$sim_root")
+        local win_path
+        win_path=$(wslpath -w "$real_root" 2>/dev/null)
+        if [ -z "$win_path" ]; then
+          echo "Error: could not translate ${real_root} to a Windows path."
+          return 1
+        fi
+        echo "Opening folder: ${win_path}"
+        explorer.exe "$win_path" >/dev/null 2>&1 &
+        disown 2>/dev/null
+      elif [ "$(uname)" = "Darwin" ]; then
+        echo "Opening folder: ${sim_root}"
+        open "$sim_root"
+      elif [ "$(uname)" = "Linux" ]; then
+        if ! command -v xdg-open >/dev/null 2>&1; then
+          echo "Error: xdg-open not found. Install xdg-utils or open manually: ${sim_root}"
+          return 1
+        fi
+        echo "Opening folder: ${sim_root}"
+        xdg-open "$sim_root" >/dev/null 2>&1 &
+        disown 2>/dev/null
+      else
+        echo "Error: unrecognized OS. 'racecar open_sim_folder' supports Windows (WSL), Mac, and Linux."
+        return 1
+      fi
+      ;;
+
     backup)
       local prev_dir="$PWD"
       cd "$RACECAR_ABSOLUTE_PATH" || return
@@ -159,6 +260,8 @@ racecar() {
       echo "  racecar remove              removes your team directory from your car."
       echo "  racecar setup               sets up your team directory on your car."
       echo "  racecar sim <file.py>       runs the specified racecar program with the simulator."
+      echo "  racecar open_sim            launches the RacecarNeo simulator GUI."
+      echo "  racecar open_sim_folder     opens the simulator folder in your file manager."
       echo "  racecar sync [labs|library|all]  copies local files to your car with rsync."
       echo "  racecar backup              downloads RACECAR code to a local backup folder."
       echo "  racecar test                prints config to check if the racecar tool is working."

--- a/racecar-student/scripts/requirements.txt
+++ b/racecar-student/scripts/requirements.txt
@@ -4,7 +4,8 @@ pandas == 2.0.3
 mypy
 nptyping == 1.4.4
 opencv-python == 4.8.1.78
-jinja2 == 3.0
-ipywidgets == 7.6.5
+jinja2 >= 3.1, < 4
+jupyterlab >= 4.0, < 5
+ipywidgets >= 8.1, < 9
 scipy == 1.10
 rich == 14.0.0

--- a/racecar-student/scripts/setup.sh
+++ b/racecar-student/scripts/setup.sh
@@ -130,13 +130,44 @@ do
     esac
 done
 
-# Resolve clone destinations up front so all three clones can run in parallel.
-SIM_DEST="${NEO_DIR}/RacecarNeo-Simulator"
+# Resolve simulator destination.
+# Windows: must clone to C: drive — UNC paths (\\wsl.localhost\...) block
+# RacecarSim.exe DLL loads (dstorage.dll and other Unity-bundled native DLLs).
+# cmd.exe runs from /tmp to dodge the UNC-cwd warning; %USERPROFILE% (not
+# %USERNAME%) is the on-disk folder name, so renamed accounts, Microsoft
+# accounts, and profile folders containing spaces all work.
+if [ "$PLATFORM" == 'windows' ]; then
+    WIN_PROFILE=$(cd /tmp && cmd.exe /c "echo %USERPROFILE%" 2>/dev/null | tr -d '\r' | tail -n1)
+    if [ -z "$WIN_PROFILE" ]; then
+        log ""
+        echo -e "\e[1;31m[ERROR] Could not detect Windows user profile via cmd.exe.\e[0m"
+        log "WSL must be able to invoke cmd.exe to install the simulator on the Windows drive."
+        log_silent "========== SETUP LOG END (ABORTED) =========="
+        exit 1
+    fi
+    WIN_PROFILE_WSL=$(wslpath -u "$WIN_PROFILE" 2>/dev/null)
+    if [ -z "$WIN_PROFILE_WSL" ] || [ ! -d "$WIN_PROFILE_WSL" ]; then
+        log ""
+        echo -e "\e[1;31m[ERROR] Windows profile path not accessible from WSL: ${WIN_PROFILE}\e[0m"
+        log_silent "========== SETUP LOG END (ABORTED) =========="
+        exit 1
+    fi
+    SIM_DEST="${WIN_PROFILE_WSL}/RacecarNeo-Simulator"
+else
+    SIM_DEST="${NEO_DIR}/RacecarNeo-Simulator"
+fi
+
 LIB_TMP="${RACECAR_DIR}/racecar-neo-library"
 LABS_TMP="${RACECAR_DIR}/racecar-neo-${CURRICULUM}-labs"
 
-# Wipe any partial prior install before cloning
+# Wipe any partial prior install before cloning. On Windows, also clear the
+# WSL-side symlink (or leftover real directory from an older in-place clone).
 rm -rf "${SIM_DEST}" "${LIB_TMP}" "${LABS_TMP}"
+if [ "$PLATFORM" == 'windows' ]; then
+    if [ -L "${NEO_DIR}/RacecarNeo-Simulator" ] || [ -e "${NEO_DIR}/RacecarNeo-Simulator" ]; then
+        rm -rf "${NEO_DIR}/RacecarNeo-Simulator"
+    fi
+fi
 
 log "[3/4] Cloning simulator, library, and labs in parallel..."
 log_silent "Clone targets: sim → ${SIM_DEST}, lib → ${LIB_TMP}, labs → ${LABS_TMP}"
@@ -225,7 +256,12 @@ log "All repositories cloned successfully."
 rm -rf "${SIM_DEST}/.git"
 
 # Post-clone wiring
-if [ "$PLATFORM" == 'mac' ]; then
+if [ "$PLATFORM" == 'windows' ]; then
+    # Symlink the Windows-side clone back into NEO_DIR so the rest of the
+    # tooling (post-setup checks, racecar_tool.sh, update.sh) sees the same
+    # ${NEO_DIR}/RacecarNeo-Simulator path on every platform.
+    ln -sfn "${SIM_DEST}" "${NEO_DIR}/RacecarNeo-Simulator"
+elif [ "$PLATFORM" == 'mac' ]; then
     chmod -R 777 "${SIM_DEST}"
 fi
 

--- a/racecar-student/scripts/setup.sh
+++ b/racecar-student/scripts/setup.sh
@@ -104,24 +104,12 @@ if [ "$ALREADY_INSTALLED" = true ]; then
     exit 1
 fi
 
-log '[1/3] Select your operating system: [windows, mac, linux]'
+log '[1/4] Select your operating system: [windows, mac, linux]'
 select PLATFORM in windows mac linux
-
 do
     case $PLATFORM in
         windows|mac|linux)
             log_silent "Platform selected: $PLATFORM"
-            cd "$SCRIPT_DIR"/..
-            cd ..
-            # Clone file from github, format dirs
-            log "Cloning simulator for ${PLATFORM}..."
-            run_cmd git clone -b "${PLATFORM}" --single-branch "${SIM_URL}"
-
-            # Allow permissions
-            if [ "$PLATFORM" == 'mac' ]; then
-                chmod -R 777 RacecarNeo-Simulator
-            fi
-
             break
             ;;
         *)
@@ -129,27 +117,12 @@ do
     esac
 done
 
-
-log '[2/3] Select your course curriculum: [oneshot, outreach, prereq, mites]'
+log '[2/4] Select your course curriculum: [oneshot, outreach, prereq, mites]'
 select CURRICULUM in oneshot outreach prereq mites
-
 do
     case $CURRICULUM in
         oneshot|outreach|prereq|mites)
             log_silent "Curriculum selected: $CURRICULUM"
-            # Go one folder back from scripts directory
-            cd "$SCRIPT_DIR"/..
-            # Set up library and labs folder w/ correct formatting
-            log "Cloning library..."
-            run_cmd git clone "${LIB_URL}"
-            mv racecar-neo-library/library library
-            rm -rf racecar-neo-library
-
-            log "Cloning ${CURRICULUM} labs..."
-            run_cmd git clone "${CURR_URL}${CURRICULUM}-labs"
-            mv "racecar-neo-${CURRICULUM}-labs"/labs labs
-            rm -rf "racecar-neo-${CURRICULUM}-labs"
-            cd "$SCRIPT_DIR"
             break
             ;;
         *)
@@ -157,20 +130,121 @@ do
     esac
 done
 
-log '[3/3] Installing all RACECAR libraries and dependencies...'
+# Resolve clone destinations up front so all three clones can run in parallel.
+SIM_DEST="${NEO_DIR}/RacecarNeo-Simulator"
+LIB_TMP="${RACECAR_DIR}/racecar-neo-library"
+LABS_TMP="${RACECAR_DIR}/racecar-neo-${CURRICULUM}-labs"
+
+# Wipe any partial prior install before cloning
+rm -rf "${SIM_DEST}" "${LIB_TMP}" "${LABS_TMP}"
+
+log "[3/4] Cloning simulator, library, and labs in parallel..."
+log_silent "Clone targets: sim → ${SIM_DEST}, lib → ${LIB_TMP}, labs → ${LABS_TMP}"
+
+SIM_CLONE_LOG="${LOG_DIR}/.clone_sim.tmp"
+LIB_CLONE_LOG="${LOG_DIR}/.clone_lib.tmp"
+LABS_CLONE_LOG="${LOG_DIR}/.clone_labs.tmp"
+
+# --depth 1 implies --single-branch; -b PLATFORM still selects sim's branch.
+git clone --depth 1 --progress -b "${PLATFORM}" "${SIM_URL}" "${SIM_DEST}" >"${SIM_CLONE_LOG}" 2>&1 &
+SIM_PID=$!
+git clone --depth 1 --progress "${LIB_URL}" "${LIB_TMP}" >"${LIB_CLONE_LOG}" 2>&1 &
+LIB_PID=$!
+git clone --depth 1 --progress "${CURR_URL}${CURRICULUM}-labs" "${LABS_TMP}" >"${LABS_CLONE_LOG}" 2>&1 &
+LABS_PID=$!
+
+# Spinner only on TTY; silent wait when piped.
+INTERACTIVE_TTY=false
+[ -t 1 ] && INTERACTIVE_TTY=true
+
+if $INTERACTIVE_TTY; then
+    echo "  [ ] simulator   starting..."
+    echo "  [ ] library     starting..."
+    echo "  [ ] labs        starting..."
+fi
+
+SPINNER='|/-\'
+SPIN_I=0
+while kill -0 "$SIM_PID" 2>/dev/null \
+   || kill -0 "$LIB_PID" 2>/dev/null \
+   || kill -0 "$LABS_PID" 2>/dev/null; do
+    if $INTERACTIVE_TTY; then
+        SPIN_C=${SPINNER:$SPIN_I:1}
+        SPIN_I=$(( (SPIN_I + 1) % 4 ))
+
+        sim_size=$(du -sh "$SIM_DEST" 2>/dev/null | cut -f1); sim_size=${sim_size:-0}
+        lib_size=$(du -sh "$LIB_TMP" 2>/dev/null | cut -f1);  lib_size=${lib_size:-0}
+        labs_size=$(du -sh "$LABS_TMP" 2>/dev/null | cut -f1); labs_size=${labs_size:-0}
+
+        kill -0 "$SIM_PID"  2>/dev/null && sim_mark="[$SPIN_C]"  || sim_mark="[✓]"
+        kill -0 "$LIB_PID"  2>/dev/null && lib_mark="[$SPIN_C]"  || lib_mark="[✓]"
+        kill -0 "$LABS_PID" 2>/dev/null && labs_mark="[$SPIN_C]" || labs_mark="[✓]"
+
+        printf '\033[3A'
+        printf '\r\033[2K  %s simulator   %s\n' "$sim_mark"  "$sim_size"
+        printf '\r\033[2K  %s library     %s\n' "$lib_mark"  "$lib_size"
+        printf '\r\033[2K  %s labs        %s\n' "$labs_mark" "$labs_size"
+    fi
+    sleep 0.3
+done
+
+if $INTERACTIVE_TTY; then
+    sim_size=$(du -sh "$SIM_DEST" 2>/dev/null | cut -f1); sim_size=${sim_size:-?}
+    lib_size=$(du -sh "$LIB_TMP" 2>/dev/null | cut -f1);  lib_size=${lib_size:-?}
+    labs_size=$(du -sh "$LABS_TMP" 2>/dev/null | cut -f1); labs_size=${labs_size:-?}
+    printf '\033[3A'
+    printf '\r\033[2K  [✓] simulator   %s\n' "$sim_size"
+    printf '\r\033[2K  [✓] library     %s\n' "$lib_size"
+    printf '\r\033[2K  [✓] labs        %s\n' "$labs_size"
+fi
+
+wait "$SIM_PID";  SIM_RC=$?
+wait "$LIB_PID";  LIB_RC=$?
+wait "$LABS_PID"; LABS_RC=$?
+
+for f in "$SIM_CLONE_LOG" "$LIB_CLONE_LOG" "$LABS_CLONE_LOG"; do
+    if [ -f "$f" ]; then
+        log_silent "----- $(basename "$f") -----"
+        cat "$f" >> "$LOG_FILE"
+        rm -f "$f"
+    fi
+done
+
+# Never proceed with a partially-cloned tree.
+if [ "$SIM_RC" -ne 0 ] || [ "$LIB_RC" -ne 0 ] || [ "$LABS_RC" -ne 0 ]; then
+    log ""
+    echo -e "\e[1;31m[ERROR] Clone failed (sim:${SIM_RC} library:${LIB_RC} labs:${LABS_RC}). See ${LOG_FILE}\e[0m"
+    log_silent "========== SETUP LOG END (ABORTED) =========="
+    exit 1
+fi
+
+log "All repositories cloned successfully."
+
+# Drop the sim's .git/ — ~150-250 MB of dead weight; students never use it.
+# (lib/labs .git/ is inside their temp wrappers, removed below.)
+rm -rf "${SIM_DEST}/.git"
+
+# Post-clone wiring
+if [ "$PLATFORM" == 'mac' ]; then
+    chmod -R 777 "${SIM_DEST}"
+fi
+
+mv "${LIB_TMP}/library" "${RACECAR_DIR}/library"
+rm -rf "${LIB_TMP}"
+mv "${LABS_TMP}/labs" "${RACECAR_DIR}/labs"
+rm -rf "${LABS_TMP}"
+
+log '[4/4] Installing all RACECAR libraries and dependencies...'
 # Install RACECAR libraries and dependencies
 if [ "$PLATFORM" == 'windows' ]; then
     log_silent "Starting Windows (WSL2) setup..."
     run_pipe "yes | sudo apt update"
-    run_pipe "yes | sudo apt upgrade"
-    run_pipe "yes | sudo apt install python-is-python3"
-    run_pipe "yes | sudo apt install python3-pip"
+    run_pipe "yes | sudo apt install -y python-is-python3 python3-pip"
 
-    # Setting up venv for Python 3.9
+    # Single post-PPA apt call — triggers/ldconfig run once instead of three times.
     run_pipe "yes | sudo add-apt-repository ppa:deadsnakes/ppa"
     run_pipe "yes | sudo apt update"
-    run_pipe "yes | sudo apt install python3.9"
-    run_pipe "yes | sudo apt install python3.9-venv"
+    run_pipe "yes | sudo apt install -y python3.9 python3.9-venv ffmpeg libsm6 libxext6"
 
     if ! command -v python3.9 &> /dev/null; then
         log ""
@@ -199,19 +273,16 @@ if [ "$PLATFORM" == 'windows' ]; then
         exit 1
     fi
 
-    # continue with regular setup
-    run_pipe "yes | sudo apt install jupyter-notebook"
-    run_pipe "yes | sudo apt install ffmpeg libsm6 libxext6 -y"
     run_cmd busybox dos2unix "${SCRIPT_DIR}"/racecar_tool.sh
 
     log_silent "Writing .config file..."
 
-    # Windows config command
+    # DISPLAY intentionally NOT set: WSL2+WSLg auto-injects DISPLAY=:0 before
+    # .bashrc; hardcoding "localhost:42.0" (legacy XLaunch) breaks Qt/cv2.imshow.
     echo "RACECAR_ABSOLUTE_PATH=${RACECAR_DIR}
 RACECAR_IP=127.0.0.1
 RACECAR_TEAM=student
-RACECAR_CONFIG_LOADED=TRUE
-export DISPLAY=localhost:42.0" > "${SCRIPT_DIR}/.config"
+RACECAR_CONFIG_LOADED=TRUE" > "${SCRIPT_DIR}/.config"
 
     log_silent "Writing .local_bashrc.sh..."
 
@@ -268,15 +339,12 @@ BASHEOF
 elif [ "$PLATFORM" == 'linux' ]; then
     log_silent "Starting Linux setup..."
     run_pipe "yes | sudo apt update"
-    run_pipe "yes | sudo apt upgrade"
-    run_pipe "yes | sudo apt install python-is-python3"
-    run_pipe "yes | sudo apt install python3-pip"
+    run_pipe "yes | sudo apt install -y python-is-python3 python3-pip"
 
-    # Setting up venv for Python 3.9
+    # Single post-PPA apt call — triggers/ldconfig run once instead of three times.
     run_pipe "yes | sudo add-apt-repository ppa:deadsnakes/ppa"
     run_pipe "yes | sudo apt update"
-    run_pipe "yes | sudo apt install python3.9"
-    run_pipe "yes | sudo apt install python3.9-venv"
+    run_pipe "yes | sudo apt install -y python3.9 python3.9-venv ffmpeg libsm6 libxext6"
 
     if ! command -v python3.9 &> /dev/null; then
         log ""
@@ -305,18 +373,15 @@ elif [ "$PLATFORM" == 'linux' ]; then
         exit 1
     fi
 
-    run_pipe "yes | sudo apt install jupyter-notebook"
-    run_pipe "yes | sudo apt install ffmpeg libsm6 libxext6 -y"
     run_cmd busybox dos2unix "${SCRIPT_DIR}"/racecar_tool.sh
 
     log_silent "Writing .config file..."
 
-    # Linux config command
+    # UDP buffer tuning lives in _racecar_tune_udp (lazy, called from 'racecar sim').
     echo "RACECAR_ABSOLUTE_PATH=${RACECAR_DIR}
 RACECAR_IP=127.0.0.1
 RACECAR_TEAM=student
-RACECAR_CONFIG_LOADED=TRUE
-sudo sysctl -w net.ipv4.udp_mem=\"65535 131071 262142\"" > "${SCRIPT_DIR}/.config"
+RACECAR_CONFIG_LOADED=TRUE" > "${SCRIPT_DIR}/.config"
 
     log_silent "Writing .local_bashrc.sh..."
 
@@ -350,19 +415,22 @@ BASHEOF
 
 elif [ "$PLATFORM" == 'mac' ]; then
     log_silent "Starting Mac setup..."
-    run_cmd xcode-select --install
+    # Skip if CLT is present — xcode-select --install exits non-zero otherwise.
+    if xcode-select -p >/dev/null 2>&1; then
+        log_silent "Xcode Command Line Tools already installed; skipping."
+    else
+        run_cmd xcode-select --install
+    fi
 
     run_cmd /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
     echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.zprofile
     echo 'eval "$(/opt/homebrew/bin/brew shellenv)"' >> ~/.bash_profile
 
-    run_cmd /bin/bash brew install python3
+    run_cmd brew install python3
 
     echo 'export PATH="/usr/local/opt/python/libexec/bin:$PATH"' >> ~/.zprofile
     echo 'export PATH="/usr/local/opt/python/libexec/bin:$PATH"' >> ~/.bash_profile
-
-    echo 'export PATH="/usr/local/opt/python/libexec/bin:$PATH"'
 
     run_cmd python3 -m pip install --upgrade pip
 
@@ -397,12 +465,11 @@ elif [ "$PLATFORM" == 'mac' ]; then
 
     log_silent "Writing .config file..."
 
-    # Mac config command
+    # UDP buffer tuning lives in _racecar_tune_udp (lazy, called from 'racecar sim').
     echo "RACECAR_ABSOLUTE_PATH=${RACECAR_DIR}
 RACECAR_IP=127.0.0.1
 RACECAR_TEAM=student
-RACECAR_CONFIG_LOADED=TRUE
-sudo sysctl -w net.inet.udp.maxdgram=65535" > "${SCRIPT_DIR}/.config"
+RACECAR_CONFIG_LOADED=TRUE" > "${SCRIPT_DIR}/.config"
 
     log_silent "Writing .local_bashrc.sh..."
 
@@ -552,13 +619,10 @@ if [ -f "${NEO_DIR}/racecar-venv/bin/activate" ]; then
         # Skip empty lines and comments
         [ -z "$line" ] && continue
         [[ "$line" =~ ^# ]] && continue
-        # Extract package name (before ==, >=, <=, ~=, or whitespace)
+        # Strip version pin (==, >=, <=, ~=, !=) to get the dist name.
         PKG_NAME=$(echo "$line" | sed 's/[=<>~!].*//' | xargs)
-        # Normalize: replace hyphens with underscores for pip check
-        if python3 -c "import importlib; importlib.import_module('${PKG_NAME//-/_}')" 2>/dev/null || \
-           pip show "$PKG_NAME" > /dev/null 2>&1; then
-            :
-        else
+        # pip show avoids the import-name-vs-dist-name trap (opencv-python → cv2).
+        if ! pip show "$PKG_NAME" > /dev/null 2>&1; then
             DEP_FAIL=$((DEP_FAIL + 1))
             DEP_MISSING="${DEP_MISSING} ${PKG_NAME}"
         fi
@@ -579,18 +643,13 @@ if [ "$PLATFORM" == 'windows' ]; then
     WSL_NET_MODE="unknown"
     SIM_IP="unknown"
 
-    # Detect WSL version
+    # WSL2's kernel release contains "WSL2"; WSL1's doesn't. osrelease is
+    # the authoritative source (more reliable than /proc/version).
     if grep -qi "microsoft" /proc/version 2>/dev/null; then
-        if grep -qi "WSL2" /proc/version 2>/dev/null; then
+        if grep -qi "WSL2" /proc/sys/kernel/osrelease 2>/dev/null; then
             WSL_VERSION="WSL2"
         else
-            # Could be WSL1 or WSL2 without "WSL2" in version string
-            # Check for Hyper-V features that only exist in WSL2
-            if [ -d "/sys/class/dmi" ] 2>/dev/null; then
-                WSL_VERSION="WSL2"
-            else
-                WSL_VERSION="WSL1"
-            fi
+            WSL_VERSION="WSL1"
         fi
     fi
 

--- a/racecar-student/scripts/setup.sh
+++ b/racecar-student/scripts/setup.sh
@@ -544,6 +544,23 @@ BASHEOF
 fi
 
 # ============================================================================
+# Wire library/ onto the venv's sys.path via a .pth file.
+# Lets students write `import racecar_core` / `import racecar_utils` with no
+# sys.path boilerplate at the top of every lab. Python auto-loads .pth files
+# from site-packages at interpreter startup.
+# ============================================================================
+if [ -f "${NEO_DIR}/racecar-venv/bin/activate" ] && [ -d "${RACECAR_DIR}/library" ]; then
+    source "${NEO_DIR}/racecar-venv/bin/activate"
+    SITE_PACKAGES=$(python3 -c 'import sysconfig; print(sysconfig.get_paths()["purelib"])' 2>/dev/null)
+    if [ -n "$SITE_PACKAGES" ] && [ -d "$SITE_PACKAGES" ]; then
+        echo "${RACECAR_DIR}/library" > "${SITE_PACKAGES}/racecar_student.pth"
+        log_silent "Wrote ${SITE_PACKAGES}/racecar_student.pth → ${RACECAR_DIR}/library"
+    else
+        log_silent "WARNING: could not resolve venv site-packages; skipping .pth wiring"
+    fi
+fi
+
+# ============================================================================
 # Post-setup verification
 # ============================================================================
 log ""
@@ -646,7 +663,19 @@ else
     check_pass "No command failures detected in log file"
 fi
 
-# 10. Python dependencies
+# 10. Library importable from venv (sys.path wiring)
+if [ -f "${NEO_DIR}/racecar-venv/bin/activate" ]; then
+    source "${NEO_DIR}/racecar-venv/bin/activate"
+    if python3 -c "import racecar_core, racecar_utils" >/dev/null 2>&1; then
+        check_pass "Library wired into venv (racecar_core, racecar_utils importable)"
+    else
+        check_fail "Library not importable from venv — .pth wiring may have failed"
+    fi
+else
+    check_fail "Cannot verify library wiring — virtual environment not found"
+fi
+
+# 11. Python dependencies
 if [ -f "${NEO_DIR}/racecar-venv/bin/activate" ]; then
     source "${NEO_DIR}/racecar-venv/bin/activate"
     DEP_FAIL=0
@@ -673,7 +702,7 @@ else
     check_fail "Cannot verify dependencies — virtual environment not found"
 fi
 
-# 11. WSL networking mode (Windows only)
+# 12. WSL networking mode (Windows only)
 if [ "$PLATFORM" == 'windows' ]; then
     WSL_VERSION="unknown"
     WSL_NET_MODE="unknown"

--- a/racecar-student/scripts/update.sh
+++ b/racecar-student/scripts/update.sh
@@ -141,19 +141,57 @@ elif [ "$FOLDER" == 'sim' ]; then
                 cd "$SCRIPT_DIR"/..
                 cd ..
 
-                # Remove current sim files
-                rm -rf RacecarNeo-Simulator
+                if [ "$PLATFORM" == 'windows' ]; then
+                    # See setup.sh: simulator lives on the Windows drive to
+                    # avoid the UNC-path DLL loader restriction;
+                    # NEO_DIR/RacecarNeo-Simulator is a symlink pointing to it.
+                    WIN_PROFILE=$(cd /tmp && cmd.exe /c "echo %USERPROFILE%" 2>/dev/null | tr -d '\r' | tail -n1)
+                    if [ -z "$WIN_PROFILE" ]; then
+                        log ""
+                        echo -e "\e[1;31m[ERROR] Could not detect Windows user profile via cmd.exe.\e[0m"
+                        log "WSL must be able to invoke cmd.exe to update the simulator on the Windows drive."
+                        log_silent "========== UPDATE LOG END (ABORTED) =========="
+                        exit 1
+                    fi
+                    WIN_PROFILE_WSL=$(wslpath -u "$WIN_PROFILE" 2>/dev/null)
+                    if [ -z "$WIN_PROFILE_WSL" ] || [ ! -d "$WIN_PROFILE_WSL" ]; then
+                        log ""
+                        echo -e "\e[1;31m[ERROR] Windows profile path not accessible from WSL: ${WIN_PROFILE}\e[0m"
+                        log_silent "========== UPDATE LOG END (ABORTED) =========="
+                        exit 1
+                    fi
+                    SIM_DIR="${WIN_PROFILE_WSL}/RacecarNeo-Simulator"
+                    log_silent "Updating simulator on Windows drive: ${SIM_DIR}"
+                    rm -rf "${SIM_DIR}"
+                    # NEO_DIR/RacecarNeo-Simulator may be a symlink (from a prior
+                    # windows setup) or a real directory (from an older setup
+                    # that cloned in-place). Handle both.
+                    if [ -L "${NEO_DIR}/RacecarNeo-Simulator" ] || [ -e "${NEO_DIR}/RacecarNeo-Simulator" ]; then
+                        rm -rf "${NEO_DIR}/RacecarNeo-Simulator"
+                    fi
+                    log "Cloning simulator for ${PLATFORM}..."
+                    # --depth 1 implies --single-branch; -b PLATFORM still
+                    # selects which branch. Drop .git/ after clone — students
+                    # don't need it.
+                    run_cmd git clone --depth 1 -b "${PLATFORM}" "${SIM_URL}" "${SIM_DIR}"
+                    rm -rf "${SIM_DIR}/.git"
+                    ln -sfn "${SIM_DIR}" "${NEO_DIR}/RacecarNeo-Simulator"
+                else
+                    # Remove current sim files
+                    rm -rf RacecarNeo-Simulator
 
-                # Clone file from github, format dirs.
-                # --depth 1 implies --single-branch; -b PLATFORM still selects
-                # which branch. Drop .git/ after clone — students don't need it.
-                log "Cloning simulator for ${PLATFORM}..."
-                run_cmd git clone --depth 1 -b "${PLATFORM}" "${SIM_URL}"
-                rm -rf RacecarNeo-Simulator/.git
+                    # Clone file from github, format dirs.
+                    # --depth 1 implies --single-branch; -b PLATFORM still
+                    # selects which branch. Drop .git/ after clone — students
+                    # don't need it.
+                    log "Cloning simulator for ${PLATFORM}..."
+                    run_cmd git clone --depth 1 -b "${PLATFORM}" "${SIM_URL}"
+                    rm -rf RacecarNeo-Simulator/.git
 
-                # Allow permissions
-                if [ "$PLATFORM" == 'mac' ]; then
-                    chmod -R 777 RacecarNeo-Simulator
+                    # Allow permissions
+                    if [ "$PLATFORM" == 'mac' ]; then
+                        chmod -R 777 RacecarNeo-Simulator
+                    fi
                 fi
 
                 break

--- a/racecar-student/scripts/update.sh
+++ b/racecar-student/scripts/update.sh
@@ -101,7 +101,7 @@ if [ "$FOLDER" == 'labs' ]; then
                 rm -rf labs
                 # Set up labs folder w/ correct formatting
                 log "Cloning ${CURRICULUM} labs..."
-                run_cmd git clone "${CURR_URL}${CURRICULUM}-labs"
+                run_cmd git clone --depth 1 "${CURR_URL}${CURRICULUM}-labs"
                 mv "racecar-neo-${CURRICULUM}-labs"/labs labs
                 rm -rf "racecar-neo-${CURRICULUM}-labs"
                 cd "$SCRIPT_DIR"
@@ -119,7 +119,7 @@ elif [ "$FOLDER" == 'library' ]; then
     rm -rf library
     # Set up library folder w/ correct formatting
     log "Cloning library..."
-    run_cmd git clone "${LIB_URL}"
+    run_cmd git clone --depth 1 "${LIB_URL}"
     mv racecar-neo-library/library library
     rm -rf racecar-neo-library
 
@@ -144,9 +144,12 @@ elif [ "$FOLDER" == 'sim' ]; then
                 # Remove current sim files
                 rm -rf RacecarNeo-Simulator
 
-                # Clone file from github, format dirs
+                # Clone file from github, format dirs.
+                # --depth 1 implies --single-branch; -b PLATFORM still selects
+                # which branch. Drop .git/ after clone — students don't need it.
                 log "Cloning simulator for ${PLATFORM}..."
-                run_cmd git clone -b "${PLATFORM}" --single-branch "${SIM_URL}"
+                run_cmd git clone --depth 1 -b "${PLATFORM}" "${SIM_URL}"
+                rm -rf RacecarNeo-Simulator/.git
 
                 # Allow permissions
                 if [ "$PLATFORM" == 'mac' ]; then
@@ -218,10 +221,10 @@ elif [ "$FOLDER" == 'library' ]; then
         while IFS= read -r line; do
             [ -z "$line" ] && continue
             [[ "$line" =~ ^# ]] && continue
+            # Strip version pin (==, >=, <=, ~=, !=) to get the dist name.
             PKG_NAME=$(echo "$line" | sed 's/[=<>~!].*//' | xargs)
-            if pip show "$PKG_NAME" > /dev/null 2>&1; then
-                :
-            else
+            # pip show avoids the import-name-vs-dist-name trap (opencv-python → cv2).
+            if ! pip show "$PKG_NAME" > /dev/null 2>&1; then
                 DEP_FAIL=$((DEP_FAIL + 1))
                 DEP_MISSING="${DEP_MISSING} ${PKG_NAME}"
             fi


### PR DESCRIPTION
Ports [MITUavNeo/uav-neo-installer#10](https://github.com/MITUavNeo/uav-neo-installer/pull/10) plus the JupyterLab slice from [#8](https://github.com/MITUavNeo/uav-neo-installer/pull/8). Excludes the WSL DLL workaround (`#9`) and the `.pth` venv wiring (`#11`) — separate follow-ups.

## Bug fixes (`setup.sh`)

- Mac: dropped bogus `/bin/bash` prefix on `brew install python3` (silent no-op).
- Mac: removed orphaned `echo 'export PATH=...'` printing to stdout.
- Mac: guarded `xcode-select --install` with `xcode-select -p` precheck (was producing spurious `[FAIL]` on Macs with CLT preinstalled).
- Dep check: dropped `importlib.import_module` branch — `pip show` alone avoids the import-name-vs-dist-name trap (`opencv-python` → `cv2`). Brings `setup.sh` in line with `update.sh`.
- WSL detection: replaced the `/sys/class/dmi` fallback (present on both WSL1 and WSL2) with `grep -qi WSL2 /proc/sys/kernel/osrelease`.

## Workflow optimizations (`setup.sh`, `update.sh`)

- Dropped unconditional `apt upgrade` (Windows + Linux). Saves 60–600s per fresh install.
- Batched 5 sequential `apt install` calls into 2 (one pre-PPA, one post-PPA folding in `ffmpeg libsm6 libxext6`). Single trigger/ldconfig run.
- Parallelized the three `git clone` operations (sim, library, labs) with a TTY spinner showing per-repo size, exit-code gate before any `mv`/`chmod`. Both `select` prompts moved to top of script. Step numbering `[1/3]…[3/3]` → `[1/4]…[4/4]`.
- Shallow clones (`--depth 1`) on all clones in `setup.sh` and `update.sh`; `rm -rf .git/` on the sim clone post-checkout. Saves ~250 MB disk per install.
- Dropped legacy `export DISPLAY=localhost:42.0` from Windows `.config` — was clobbering WSLg's auto-injected `DISPLAY=:0` and breaking Qt/`cv2.imshow()`.

## Lazy UDP buffer tuning (`racecar_tool.sh`, `setup.sh`)

The `sudo sysctl -w` line previously written into `.config` on Linux/Mac prompted for a password on every shell startup, even when not using the simulator. Now lives in a new `_racecar_tune_udp` helper in `racecar_tool.sh`, invoked from `racecar sim`, gated by `RACECAR_UDP_TUNED` (once per session) and an idempotency check via `sysctl -n` (skips sudo when value is already correct). WSL is an explicit no-op — Windows handles its own buffers.

## JupyterLab migration (`requirements.txt`, `racecar_tool.sh`, `setup.sh`)

Migrated off `apt install jupyter-notebook` to pip-installed `jupyterlab >= 4.0, < 5`. Loosened `jinja2` and `ipywidgets` pins to JupyterLab-4-compatible ranges. `racecar jupyter` now runs `jupyter lab --no-browser`. Side benefit: Mac never had `jupyter-notebook` installed at all (no apt branch on Mac), so this also closes that latent gap.